### PR TITLE
Add ability to create an iterator from an RLP list

### DIFF
--- a/contracts/Helper.sol
+++ b/contracts/Helper.sol
@@ -9,6 +9,7 @@ contract Helper {
     using RLPReader for bytes;
     using RLPReader for uint;
     using RLPReader for RLPReader.RLPItem;
+    using RLPReader for RLPReader.Iterator;
 
     function isList(bytes memory item) public pure returns (bool) {
         RLPReader.RLPItem memory rlpItem = item.toRlpItem();
@@ -72,6 +73,30 @@ contract Helper {
     function bytesToString(bytes memory item) public pure returns (string memory) {
         RLPReader.RLPItem memory rlpItem = item.toRlpItem();
         return string(rlpItem.toBytes());
+    }
+
+    function toBlockHeader(bytes memory rlpHeader) public pure returns (
+        bytes32 parentHash, bytes32 sha3Uncles, bytes32 stateRoot, bytes32 transactionsRoot, bytes32 receiptsRoot,
+        uint difficulty, uint number, uint gasLimit, uint gasUsed, uint timestamp, uint nonce) {
+
+        RLPReader.Iterator memory it = rlpHeader.toRlpItem().iterator();
+        uint idx;
+        while(it.hasNext()) {
+            if ( idx == 0 )      parentHash       = bytes32(it.next().toUint());
+            else if ( idx == 1 ) sha3Uncles       = bytes32(it.next().toUint());
+            else if ( idx == 3 ) stateRoot        = bytes32(it.next().toUint());
+            else if ( idx == 4 ) transactionsRoot = bytes32(it.next().toUint());
+            else if ( idx == 5 ) receiptsRoot     = bytes32(it.next().toUint());
+            else if ( idx == 7 ) difficulty       = it.next().toUint();
+            else if ( idx == 8 ) number           = it.next().toUint();
+            else if ( idx == 9 ) gasLimit         = it.next().toUint();
+            else if ( idx == 10 ) gasUsed         = it.next().toUint();
+            else if ( idx == 11 ) timestamp       = it.next().toUint();
+            else if ( idx == 14 ) nonce           = it.next().toUint();
+            else it.next();
+
+            idx++;
+        }
     }
 
     /* custom destructuring */

--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -9,10 +9,6 @@ library RLPReader {
     uint8 constant STRING_LONG_START  = 0xb8;
     uint8 constant LIST_SHORT_START   = 0xc0;
     uint8 constant LIST_LONG_START    = 0xf8;
-
-    uint constant STRING_LONG_OFFSET = 0xb7;
-    uint constant LIST_LONG_OFFSET = 0xf7;
-
     uint8 constant WORD_SIZE = 32;
 
     struct RLPItem {
@@ -25,19 +21,25 @@ library RLPReader {
         uint nextPtr;   // Position of the next item in the list.
     }
 
-    /* Iterator */
+    /*
+    * @dev Returns the next element in the iteration. Reverts if it has not next element.
+    * @param self The iterator.
+    * @return The next element in the iteration.
+    */
     function next(Iterator memory self) internal pure returns (RLPItem memory subItem) {
-        if(hasNext(self)) {
-            uint ptr = self.nextPtr;
-            uint itemLength = _itemLength(ptr);
-            subItem.memPtr = ptr;
-            subItem.len = itemLength;
-            self.nextPtr = ptr + itemLength;
-        }
-        else
-            revert("no next item");
+        require(hasNext(self));
+        uint ptr = self.nextPtr;
+        uint itemLength = _itemLength(ptr);
+        subItem.memPtr = ptr;
+        subItem.len = itemLength;
+        self.nextPtr = ptr + itemLength;
     }
 
+    /*
+    * @dev Returns true if the iteration has more elements.
+    * @param self The iterator.
+    * @return true if the iteration has more elements.
+    */
     function hasNext(Iterator memory self) internal pure returns (bool) {
         RLPItem memory item = self.item;
         return self.nextPtr < item.memPtr + item.len;
@@ -56,13 +58,12 @@ library RLPReader {
     }
 
     /*
-    * @dev Create an iterator.
+    * @dev Create an iterator. Reverts if item is not a list.
     * @param self The RLP item.
     * @return An 'Iterator' over the item.
     */
     function iterator(RLPItem memory self) internal pure returns (Iterator memory it) {
-        if (!isList(self))
-            revert("iterator has to be created from a list");
+        require(isList(self));
         uint ptr = self.memPtr + _payloadOffset(self.memPtr);
         it.item = self;
         it.nextPtr = ptr;

--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -10,11 +10,37 @@ library RLPReader {
     uint8 constant LIST_SHORT_START   = 0xc0;
     uint8 constant LIST_LONG_START    = 0xf8;
 
+    uint constant STRING_LONG_OFFSET = 0xb7;
+    uint constant LIST_LONG_OFFSET = 0xf7;
+
     uint8 constant WORD_SIZE = 32;
 
     struct RLPItem {
         uint len;
         uint memPtr;
+    }
+
+    struct Iterator {
+        RLPItem item;   // Item that's being iterated over.
+        uint nextPtr;   // Position of the next item in the list.
+    }
+
+    /* Iterator */
+    function next(Iterator memory self) internal pure returns (RLPItem memory subItem) {
+        if(hasNext(self)) {
+            uint ptr = self.nextPtr;
+            uint itemLength = _itemLength(ptr);
+            subItem.memPtr = ptr;
+            subItem.len = itemLength;
+            self.nextPtr = ptr + itemLength;
+        }
+        else
+            revert("no next item");
+    }
+
+    function hasNext(Iterator memory self) internal pure returns (bool) {
+        RLPItem memory item = self.item;
+        return self.nextPtr < item.memPtr + item.len;
     }
 
     /*
@@ -27,6 +53,19 @@ library RLPReader {
         }
 
         return RLPItem(item.length, memPtr);
+    }
+
+    /*
+    * @dev Create an iterator.
+    * @param self The RLP item.
+    * @return An 'Iterator' over the item.
+    */
+    function iterator(RLPItem memory self) internal pure returns (Iterator memory it) {
+        if (!isList(self))
+            revert("iterator has to be created from a list");
+        uint ptr = self.memPtr + _payloadOffset(self.memPtr);
+        it.item = self;
+        it.nextPtr = ptr;
     }
 
     /*


### PR DESCRIPTION
The pull request adds the ability to create an iterator from an RLP list. 

This is useful to iterate over the different fields of an RLP list, e.g. iterate over the different fields of an Ethereum block header:

```
        RLPReader.Iterator memory it = rlpHeader.toRlpItem().iterator();
        BlockHeader memory header;
        uint idx;
        while(it.hasNext()) {
            if( idx == 0 ) header.parent = it.next().toBytes32();
            else if ( idx == 1 ) header.uncleHash = it.next().toBytes32();
            else if ( idx == 3 ) header.stateRoot = it.next().toBytes32();
            else if ( idx == 4 ) header.transactionsRoot = it.next().toBytes32();
            else if ( idx == 5 ) header.receiptsRoot = it.next().toBytes32();
            else if ( idx == 7 ) header.difficulty = it.next().toUint();
            else if ( idx == 8 ) header.blockNumber = it.next().toUint();
            else if ( idx == 9 ) header.gasLimit = it.next().toUint();
            else if ( idx == 10 ) header.gasUsed = it.next().toUint();
            else if ( idx == 11 ) header.timestamp = it.next().toUint();
            else if ( idx == 14 ) header.nonce = it.next().toUint();
            else it.next();

            idx++;
        }
```

The code snippets were taken and adapted from https://github.com/androlo/standard-contracts/blob/master/contracts/src/codec/RLP.sol.