### PR TITLE
Implement a cheap keccak256 of item contents

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.4
+### Added
+- `rlpBytesKeccak256(RLPItem)` returns keccak256 hash of RLP encoded bytes.
+- `payloadKeccak256(RLPItem)` returns keccak256 hash of the item payload.
+
 ## 2.0.3
 ### Added
 - support for solidity 0.6.x

--- a/README.md
+++ b/README.md
@@ -14,24 +14,26 @@ The reader contract provides an interface to first take RLP encoded bytes and co
 an internal data structure, `RLPItem` through the function, `toRlpItem(bytes)`. This data structure can then be
 destructured into the desired data types.
 
-Transformations(All take an RLPItem as an arg):  
+Transformations (all take an RLPItem as an arg):
 1. `isList(RLPItem) bool` : inidicator if the encoded data is a list
 2. `toList(RLPItem) RLPItem[]` : returns a list of RLPItems
-3. `iterator(RLPITem) Iterator` : returns an `Iterator` over the RLPItem. RLPItem must be an encoded list
-4. `toBytes(RLPItem) bytes` : returns the payload in bytes
-5. `toAddress(RLPItem) address` : returns the encoded address. Must be exactly 20 bytes.
-6. `toUint(RLPItem) uint` : returns the encoded uint. Enforced data is capped to 32 bytes.
-7. `toUintStrict(RLPItem) uint` : returns the encoded uint. Encoded data must be padded to 32 bytes.
-8. `toBoolean(RLPItem) bool`: returns the encoded boolean
-9. `toRlpBytes(RLPItem) bytes `: returns the raw rlp encoded byte form
-10. `rlpLen(RLPItem) uint` : returns the byte length of the rlp item
-11. `payloadLen(RLPItem) uint` : returns the byte length of the data payload
-12. `hasNext(Iterator) bool` : indicator if there is another item to iterate on
-13. `next(Iterator) RLPItem` : returns the next `RLPItem` in the iterator
+3. `toBytes(RLPItem) bytes` : returns the payload in bytes
+4. `toAddress(RLPItem) address` : returns the encoded address. Must be exactly 20 bytes.
+5. `toUint(RLPItem) uint` : returns the encoded uint. Enforced data is capped to 32 bytes.
+6. `toUintStrict(RLPItem) uint` : returns the encoded uint. Encoded data must be padded to 32 bytes.
+7. `toBoolean(RLPItem) bool` : returns the encoded boolean
+8. `toRlpBytes(RLPItem) bytes ` : returns the raw rlp encoded byte form
+9. `rlpLen(RLPItem) uint` : returns the byte length of the rlp item
+10. `payloadLen(RLPItem) uint` : returns the byte length of the data payload
 
 **Note**: The reader contract only provides only these conversion functions. All other solidity data types can be derived from
 this base. For example, a `bytes32` encoded data type is equivalent to `bytes32(toUint(RLPItem))`. Start with a uint and convert from there.
 A string can be retrieved by `string(toBytes(RLPItem))`. See example for a sample smart contract.
+
+Iteration functions:
+1. `iterator(RLPItem) Iterator` : returns an `Iterator` over the RLPItem. RLPItem must be an encoded list
+2. `hasNext(Iterator) bool` : indicator if there is another item to iterate on
+3. `next(Iterator) RLPItem` : returns the next `RLPItem` in the iterator
 
 ## Example
 ```solidity

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Iteration functions:
 2. `hasNext(Iterator) bool` : indicator if there is another item to iterate on
 3. `next(Iterator) RLPItem` : returns the next `RLPItem` in the iterator
 
+Utility functions:
+1. `rlpBytesKeccak256(RLPItem) bytes32` : returns keccak256 hash of RLP encoded bytes. A cheap version
+   of `keccak256(toRlpBytes(RLPItem))` that avoids copying memory.
+2. `payloadKeccak256(RLPItem) bytes32` : returns keccak256 hash of the item payload. A cheap
+   version of `keccak256(toBytes(RLPItem))` that avoids copying memory.
+
 ## Example
 ```solidity
 import "solidity-rlp/contracts/RLPReader.sol"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RLP decoder/reader
-[![Build Status](https://travis-ci.com/hamdiallam/Solidity-RLP.svg?branch=master)](https://travis-ci.com/hamdiallam/Solidity-RLP)  
-Currently support for solidity **v0.5.0**  
+[![Build Status](https://travis-ci.com/hamdiallam/Solidity-RLP.svg?branch=master)](https://travis-ci.com/hamdiallam/Solidity-RLP)
+Currently supports solidity **v0.6.0**
 > Please raise issues for bugs, and solidity updates. I will be monitoring the solidity changelogs and updating this package accordingly
 
 ## Installation

--- a/contracts/Helper.sol
+++ b/contracts/Helper.sol
@@ -42,6 +42,11 @@ contract Helper {
         return rlpItem.length;
     }
 
+    function rlpBytesKeccak256(bytes memory item) public pure returns (bytes32) {
+        RLPReader.RLPItem memory rlpItem = item.toRlpItem();
+        return rlpItem.rlpBytesKeccak256();
+    }
+
     function toRlpBytes(bytes memory item) public pure returns (bytes memory) {
         RLPReader.RLPItem memory rlpItem = item.toRlpItem();
         return rlpItem.toRlpBytes();

--- a/contracts/Helper.sol
+++ b/contracts/Helper.sol
@@ -47,6 +47,11 @@ contract Helper {
         return rlpItem.rlpBytesKeccak256();
     }
 
+    function payloadKeccak256(bytes memory item) public pure returns (bytes32) {
+        RLPReader.RLPItem memory rlpItem = item.toRlpItem();
+        return rlpItem.payloadKeccak256();
+    }
+
     function toRlpBytes(bytes memory item) public pure returns (bytes memory) {
         RLPReader.RLPItem memory rlpItem = item.toRlpItem();
         return rlpItem.toRlpBytes();
@@ -135,6 +140,13 @@ contract Helper {
         RLPReader.RLPItem[] memory items = item.toRlpItem().toList();
         items = items[0].toList();
         return (items[0].toAddress(), items[1].toUint());
+    }
+
+    // expects [[bytes, bytes]]
+    function customNestedDestructureKeccak(bytes memory item) public pure returns (bytes32, bytes32) {
+        RLPReader.RLPItem[] memory items = item.toRlpItem().toList();
+        items = items[0].toList();
+        return (items[0].payloadKeccak256(), items[1].payloadKeccak256());
     }
 
     function customNestedToRlpBytes(bytes memory item) public pure returns (bytes memory) {

--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -121,6 +121,20 @@ library RLPReader {
         return true;
     }
 
+    /*
+     * @dev A cheaper version of keccak256(toRlpBytes(item)) that avoids copying memory.
+     * @return keccak256 hash of RLP encoded bytes.
+     */
+    function rlpBytesKeccak256(RLPItem memory item) internal pure returns (bytes32) {
+        uint256 ptr = item.memPtr;
+        uint256 len = item.len;
+        bytes32 result;
+        assembly {
+            result := keccak256(ptr, len)
+        }
+        return result;
+    }
+
     /** RLPItem conversions into data types **/
 
     // @returns raw rlp encoding in bytes

--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -135,6 +135,21 @@ library RLPReader {
         return result;
     }
 
+    /*
+     * @dev A cheaper version of keccak256(toBytes(item)) that avoids copying memory.
+     * @return keccak256 hash of the item payload.
+     */
+    function payloadKeccak256(RLPItem memory item) internal pure returns (bytes32) {
+        uint256 offset = _payloadOffset(item.memPtr);
+        uint256 ptr = item.memPtr + offset;
+        uint len = item.len - offset;
+        bytes32 result;
+        assembly {
+            result := keccak256(ptr, len)
+        }
+        return result;
+    }
+
     /** RLPItem conversions into data types **/
 
     // @returns raw rlp encoding in bytes

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -334,4 +334,17 @@ contract("RLPReader", async (accounts) => {
         assert.equal(result[0], web3.utils.keccak256(data_0_0), "item [0][0]");
         assert.equal(result[1], web3.utils.keccak256(data_0_1), "item [0][1]");
     });
+
+    it("payloadKeccak256 for empty payload is the same as keccak256(new bytes(0))", async () => {
+        // keccak256(new bytes(0))
+        const EMPTY_BYTES_HASH = '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
+
+        const emptyListRlpBytes = rlp.encode([]); // 0xc0
+        const emptyListDataHash = await helper.payloadKeccak256.call(emptyListRlpBytes);
+        assert.equal(emptyListDataHash, EMPTY_BYTES_HASH, "empty list");
+
+        const emptyBytesRlpBytes = rlp.encode(Buffer.alloc(0)); // 0x80
+        const emptyBytesDataHash = await helper.payloadKeccak256.call(emptyBytesRlpBytes);
+        assert.equal(emptyBytesDataHash, EMPTY_BYTES_HASH, "empty bytes");
+    })
 });

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -312,4 +312,26 @@ contract("RLPReader", async (accounts) => {
         result = await helper.rlpBytesKeccak256.call(toHex(data));
         assert.equal(result, web3.utils.keccak256(data), "list");
     });
+
+    it("correctly computes keccak256 hash of the item payload", async () => {
+        const data = '0xdeadbeef';
+        const rlpBytes = rlp.encode(Buffer.from(data.slice(2), 'hex'));
+        const result = await helper.payloadKeccak256.call(rlpBytes);
+        assert.equal(result, web3.utils.keccak256(data));
+    });
+
+    it("correctly computes keccak256 hash of the item payload (nested list)", async () => {
+        const data_0_0 = '0xdeadbeef';
+        const data_0_1 = '0xaabbcc';
+
+        const rlpBytes = rlp.encode([[
+            Buffer.from(data_0_0.slice(2), 'hex'),
+            Buffer.from(data_0_1.slice(2), 'hex')
+        ]]);
+
+        const result = await helper.customNestedDestructureKeccak.call(rlpBytes);
+
+        assert.equal(result[0], web3.utils.keccak256(data_0_0), "item [0][0]");
+        assert.equal(result[1], web3.utils.keccak256(data_0_1), "item [0][1]");
+    });
 });

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -298,4 +298,18 @@ contract("RLPReader", async (accounts) => {
         assert(result.timestamp == block.timestamp, "timestamp not equal");
         assert(result.nonce.toString() == web3.utils.toBN(block.nonce).toString(), "nonce not equal");
     });
+
+    it("correctly computes keccak256 hash of RLP bytes", async () => {
+        let data = rlp.encode("foo");
+        let result = await helper.rlpBytesKeccak256.call(toHex(data));
+        assert.equal(result, web3.utils.keccak256(data), "string");
+
+        data = rlp.encode(42);
+        result = await helper.rlpBytesKeccak256.call(toHex(data));
+        assert.equal(result, web3.utils.keccak256(data), "uint");
+
+        data = rlp.encode(["foo", 42]);
+        result = await helper.rlpBytesKeccak256.call(toHex(data));
+        assert.equal(result, web3.utils.keccak256(data), "list");
+    });
 });


### PR DESCRIPTION
One of the applications of this library is verifying Merkle Particia proofs. When doing this, one needs to compute multiple hashes of RLP-encoded items and their underlying data which can currently be accomplished as follows:

```solidity
bytes32 rlpBytesHash = keccak256(RLPReader.toRlpBytes(item));
bytes32 payloadHash = keccak256(RLPReader.toBytes(item));
```

However, calling `toRlpBytes()` and `toBytes()` entails copying contents of the item to a different location in memory, spending unnecessary gas. This PR adds `rlpBytesKeccak256(RLPItem memory)` and `payloadKeccak256(RLPItem memory)` functions which perform hashing in-place:

```solidity
bytes32 rlpBytesHash = RLPReader.rlpBytesKeccak256(item);
bytes32 payloadHash = RLPReader.payloadKeccak256(item);
```

This yields significant gas savings, e.g. hashing RLP-encoded 512-byte payload costs `248` gas instead of `2522`, and hashing RLP-encoded 1024-byte payload costs `344` gas instead of `4514`.