### PR TITLE
Allow to retrieve payload memory pointer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 ### Added
 - `rlpBytesKeccak256(RLPItem)` returns keccak256 hash of RLP encoded bytes.
 - `payloadKeccak256(RLPItem)` returns keccak256 hash of the item payload.
+- `payloadLocation(RLPItem) (uint memPtr, uint len)` returns the memory pointer and byte length of
+  the data payload.
 
 ## 2.0.3
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Transformations (all take an RLPItem as an arg):
 7. `toBoolean(RLPItem) bool` : returns the encoded boolean
 8. `toRlpBytes(RLPItem) bytes ` : returns the raw rlp encoded byte form
 9. `rlpLen(RLPItem) uint` : returns the byte length of the rlp item
-10. `payloadLen(RLPItem) uint` : returns the byte length of the data payload
+10. `payloadLocation(RLPItem) (uint memPtr, uint len)` : returns the memory pointer and byte length of the data payload
+11. `payloadLen(RLPItem) uint` : returns the byte length of the data payload; an alias to payloadLocation(item)[1]
 
 **Note**: The reader contract only provides only these conversion functions. All other solidity data types can be derived from
 this base. For example, a `bytes32` encoded data type is equivalent to `bytes32(toUint(RLPItem))`. Start with a uint and convert from there.

--- a/contracts/Helper.sol
+++ b/contracts/Helper.sol
@@ -32,9 +32,14 @@ contract Helper {
         return rlpItem.rlpLen();
     }
 
-    function payloadLen(bytes memory item) public pure returns (uint) {
+    function payloadLocation(bytes memory item) public pure returns (
+        uint payloadMemPtr,
+        uint payloadLen,
+        uint itemMemPtr
+    ) {
         RLPReader.RLPItem memory rlpItem = item.toRlpItem();
-        return rlpItem.payloadLen();
+        (uint memPtr, uint len) = rlpItem.payloadLocation();
+        return (memPtr, len, rlpItem.memPtr);
     }
 
     function numItems(bytes memory item) public pure returns (uint) {

--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -73,21 +73,21 @@ library RLPReader {
     }
 
     /*
-    * @param item RLP encoded bytes
+    * @param the RLP item.
     */
     function rlpLen(RLPItem memory item) internal pure returns (uint) {
         return item.len;
     }
 
     /*
-    * @param item RLP encoded bytes
+    * @param the RLP item.
     */
     function payloadLen(RLPItem memory item) internal pure returns (uint) {
         return item.len - _payloadOffset(item.memPtr);
     }
 
     /*
-    * @param item RLP encoded list in bytes
+    * @param the RLP item containing the encoded list.
     */
     function toList(RLPItem memory item) internal pure returns (RLPItem[] memory) {
         require(isList(item));

--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -80,10 +80,22 @@ library RLPReader {
     }
 
     /*
+     * @param the RLP item.
+     * @return (memPtr, len) pair: location of the item's payload in memory.
+     */
+    function payloadLocation(RLPItem memory item) internal pure returns (uint, uint) {
+        uint offset = _payloadOffset(item.memPtr);
+        uint memPtr = item.memPtr + offset;
+        uint len = item.len - offset; // data length
+        return (memPtr, len);
+    }
+
+    /*
     * @param the RLP item.
     */
     function payloadLen(RLPItem memory item) internal pure returns (uint) {
-        return item.len - _payloadOffset(item.memPtr);
+        (, uint len) = payloadLocation(item);
+        return len;
     }
 
     /*
@@ -140,12 +152,10 @@ library RLPReader {
      * @return keccak256 hash of the item payload.
      */
     function payloadKeccak256(RLPItem memory item) internal pure returns (bytes32) {
-        uint256 offset = _payloadOffset(item.memPtr);
-        uint256 ptr = item.memPtr + offset;
-        uint len = item.len - offset;
+        (uint memPtr, uint len) = payloadLocation(item);
         bytes32 result;
         assembly {
-            result := keccak256(ptr, len)
+            result := keccak256(memPtr, len)
         }
         return result;
     }
@@ -196,11 +206,9 @@ library RLPReader {
     function toUint(RLPItem memory item) internal pure returns (uint) {
         require(item.len > 0 && item.len <= 33);
 
-        uint offset = _payloadOffset(item.memPtr);
-        uint len = item.len - offset;
+        (uint memPtr, uint len) = payloadLocation(item);
 
         uint result;
-        uint memPtr = item.memPtr + offset;
         assembly {
             result := mload(memPtr)
 
@@ -230,8 +238,7 @@ library RLPReader {
     function toBytes(RLPItem memory item) internal pure returns (bytes memory) {
         require(item.len > 0);
 
-        uint offset = _payloadOffset(item.memPtr);
-        uint len = item.len - offset; // data length
+        (uint memPtr, uint len) = payloadLocation(item);
         bytes memory result = new bytes(len);
 
         uint destPtr;
@@ -239,7 +246,7 @@ library RLPReader {
             destPtr := add(0x20, result)
         }
 
-        copy(item.memPtr + offset, destPtr, len);
+        copy(memPtr, destPtr, len);
         return result;
     }
 

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -98,17 +98,29 @@ contract("RLPReader", async (accounts) => {
         assert(result.toNumber() == 1, "Incorrect calculate rlp item byte length for empty list");
     });
 
-    it("detects the payload length of encoded data", async () => {
+    it("returns the correct payload memory offset and length", async () => {
         let result;
 
-        result = await helper.payloadLen.call(toHex(rlp.encode(1)));
-        assert(result.toNumber() == 1, "incorrect payload length of a single byte encoding");
+        result = await helper.payloadLocation.call(toHex(rlp.encode(1)));
+        assert(result.payloadLen.toNumber() == 1, "incorrect payload length of a single byte encoding");
+        assert(
+            result.payloadMemPtr.toNumber() - result.itemMemPtr.toNumber() == 0,
+            "incorrect payload offset of a single byte encoding"
+        );
 
-        result = await helper.payloadLen.call(toHex(rlp.encode(toHex(Array(36).fill(0).join('')))));
-        assert(result.toNumber() == 18, "incorrect payload length of a 18 bytes");
+        result = await helper.payloadLocation.call(toHex(rlp.encode(toHex(Array(36).fill(0).join('')))));
+        assert(result.payloadLen.toNumber() == 18, "incorrect payload length of a 18 bytes");
+        assert(
+            result.payloadMemPtr.toNumber() - result.itemMemPtr.toNumber() == 1,
+            "incorrect payload offset of a 18 bytes"
+        );
 
-        result = await helper.payloadLen.call(toHex(rlp.encode(toHex(Array(200).fill(0).join('')))));
-        assert(result.toNumber() == 100, "incorrect payload length of a 100 bytes");
+        result = await helper.payloadLocation.call(toHex(rlp.encode(toHex(Array(200).fill(0).join('')))));
+        assert(result.payloadLen.toNumber() == 100, "incorrect payload length of a 100 bytes");
+        assert(
+            result.payloadMemPtr.toNumber() - result.itemMemPtr.toNumber() == 2,
+            "incorrect payload offset of a 100 bytes"
+        );
     });
 
     it("detects the correct amount of items in a list", async () => {


### PR DESCRIPTION
Add the `payloadLocation(RLPItem)` function that returns a tuple: payload memory pointer and byte length.

> Extracted from [a discussion](https://github.com/hamdiallam/Solidity-RLP/pull/10#pullrequestreview-622532991) in #10. This PR is based off that PR's branch so it contains the same commits plus the one tha adds `payloadLocation`.

This allows saving gas while performing custom read-only operations over the item payload. One example of this is Merkle Patricia proof verification, when there is a need to decode a compact representation of the node path (stored as bytes) into a memory byte array with the full representation which is twice in size. It's much more efficient to allocate only the resulting byte array and then iterate over the compact representation memory, decoding it and filling the resulting bytes.

The current library API doesn't provide a way to get the memory pointer, so, to obtain the payload, one needs to call `toBytes(item)` which copies it to a new memory location and unnecessarily spends gas. The newly-introduced function solves this problem. It's pretty low-level, but the library itself is pretty low-level already since it provides access to memptr of the RLP item via `item.memPtr`.

I've decided to keep the `payloadLen(RLPItem)` function despite it now being redundant. The main reason is to avoid introducing breaking API changes. If you're ok with a major release, feel free to remove it (or ask me to do this).

Another option would be to add `payloadMemPtr(RLPItem)` function, but that would lead to computing payload offset twice in cases when both payload memory pointer and length are needed, and one rarely needs memory pointer without the data length.