### PR TITLE
Save gas when copying memory of length that's a multiple of 32 bytes

### DIFF
--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -346,12 +346,14 @@ library RLPReader {
             dest += WORD_SIZE;
         }
 
-        // left over bytes. Mask is used to remove unwanted bytes from the word
-        uint mask = 256 ** (WORD_SIZE - len) - 1;
-        assembly {
-            let srcpart := and(mload(src), not(mask)) // zero out src
-            let destpart := and(mload(dest), mask) // retrieve the bytes
-            mstore(dest, or(destpart, srcpart))
+        if (len > 0) {
+            // left over bytes. Mask is used to remove unwanted bytes from the word
+            uint mask = 256 ** (WORD_SIZE - len) - 1;
+            assembly {
+                let srcpart := and(mload(src), not(mask)) // zero out src
+                let destpart := and(mload(dest), mask) // retrieve the bytes
+                mstore(dest, or(destpart, srcpart))
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, there are two unnecessary `MLOAD`s and one `MSTORE` performed when copying a memory chunk which length is a multiple of the word size (32 bytes).

Since 32 bytes is a common multiplier of various data structure sizes, it makes sense to specifically optimize this case.