### PR TITLE
Add length check when parsing to list

### DIFF
--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -115,6 +115,8 @@ library RLPReader {
             memPtr = memPtr + dataLen;
         }
 
+        require(memPtr - item.memPtr == item.len);
+
         return result;
     }
 


### PR DESCRIPTION
This PR adds a length check in `toList` for the RLP item when parsing to a list. 